### PR TITLE
Utilize setName as category name instead of generic const Sets

### DIFF
--- a/BetterBags_ItemRack.toc
+++ b/BetterBags_ItemRack.toc
@@ -2,7 +2,7 @@
 ## Title: BetterBags - ItemRack
 ## Notes: Add a category to BetterBags for ItemRack sets
 ## Author: DJSchaffner
-## Version: @1.2.1
+## Version: @1.3.0
 ## Dependencies: BetterBags
 
 main.lua

--- a/main.lua
+++ b/main.lua
@@ -7,7 +7,7 @@ local L = addonBetterBags:GetModule('Localization')
 
 local debug = false
 local frame = CreateFrame("Frame", nil)
-local labels = {}
+local customCategories = {}
 -------------------------------------------------------
 local function printChat(message)
 	if debug == true then
@@ -27,9 +27,9 @@ end
 
 local function updateCategories()
 	-- Wipe custom categories since we can't retrieve deleted set from itemRack (Except maybe store duplicate of sets and check last version of it)
-	for label, _ in pairs(labels) do
+	for category, _ in pairs(customCategories) do
 		-- @TODO completely remove label as custom category from BetterBags
-		categories:WipeCategory(L:G(label))
+		customCategories:WipeCategory(L:G(category))
 	end
 
 	-- Keep track of all used items and their associated sets
@@ -71,9 +71,9 @@ local function updateCategories()
 			label = "Sets: ".. table.concat(sets, ", ")
 		end
 
-		table.insert(labels, L:G(label))
+		table.insert(customCategories, L:G(label))
 		categories:AddItemToCategory(item, L:G(label))
-		-- printChat("Added item '" .. id .. "' to '" .. categoryName .. "' category")
+		-- printChat("Added item '" .. id .. "' to '" .. label .. "' category")
 	end
 end
 

--- a/main.lua
+++ b/main.lua
@@ -33,6 +33,7 @@ local function updateCategory()
 	for setName, _ in pairs(ItemRackUser.Sets) do
 		-- Only update user sets (internals start with '~')
 		if not string.match(setName, "^~") then
+			categories:WipeCategory(L:G(setName))
 			printChat("Updating set: " .. setName)
 			-- Loop all items of set
 			for _, item in pairs(ItemRackUser.Sets[setName].equip) do
@@ -40,7 +41,7 @@ local function updateCategory()
 
 				-- Adding items that don't exist causes errors
 				if id ~= 0 then
-					categories:AddItemToCategory(id, L:G(categoryName))
+					categories:AddItemToCategory(id, L:G(setName))
 					--printChat("Added item '" .. id .. "' to '" .. categoryName .. "' category")
 				end
 			end

--- a/main.lua
+++ b/main.lua
@@ -44,7 +44,7 @@ local function findSetsForItem(searchId)
 	return sets
 end
 
-local function updateCategory()
+local function updateCategories()
 	-- Wipe category since we can't retrieve deleted set from itemRack (Except maybe store duplicate of sets and check last version of it)
 	categories:WipeCategory(L:G(categoryName))
 
@@ -82,7 +82,7 @@ end
 
 local function itemRackUpdated(event, eventData)
 	printChat(event)
-	updateCategory()
+	updateCategories()
 end
 -------------------------------------------------------
 frame:RegisterEvent("ADDON_LOADED")
@@ -94,6 +94,6 @@ frame:SetScript("OnEvent", function(self, event, addon, ...)
 
 		printChat("ItemRack Loaded..")
 		printChat("Initializing Category..")
-		updateCategory()
+		updateCategories()
 	end
 end)

--- a/main.lua
+++ b/main.lua
@@ -28,6 +28,7 @@ end
 local function updateCategories()
 	-- Wipe custom categories since we can't retrieve deleted set from itemRack (Except maybe store duplicate of sets and check last version of it)
 	for label, _ in pairs(labels) do
+		-- @TODO completely remove label as custom category from BetterBags
 		categories:WipeCategory(L:G(label))
 	end
 

--- a/main.lua
+++ b/main.lua
@@ -11,7 +11,7 @@ local customCategories = {}
 -------------------------------------------------------
 local function printChat(message)
 	if debug == true then
-		print("[BetterBags ItemRack] "..message)
+		print("[BetterBags ItemRack] ".. tostring(message))
 	end
 end
 

--- a/main.lua
+++ b/main.lua
@@ -29,7 +29,8 @@ local function updateCategories()
 	-- Wipe custom categories since we can't retrieve deleted set from itemRack (Except maybe store duplicate of sets and check last version of it)
 	for category, _ in pairs(customCategories) do
 		-- @TODO completely remove label as custom category from BetterBags
-		customCategories:WipeCategory(L:G(category))
+		categories:WipeCategory(L:G(category))
+		printChat("Wiped category '" .. L:G(category) .. "'")
 	end
 
 	-- Keep track of all used items and their associated sets

--- a/main.lua
+++ b/main.lua
@@ -92,7 +92,7 @@ frame:SetScript("OnEvent", function(self, event, addon, ...)
 		
 
 		printChat("ItemRack Loaded..")
-		printChat("Initializing Category..")
+		printChat("Initializing Categories..")
 		updateCategories()
 	end
 end)

--- a/main.lua
+++ b/main.lua
@@ -72,7 +72,7 @@ local function updateCategories()
 			label = "Sets: ".. table.concat(sets, ", ")
 		end
 
-		table.insert(customCategories, L:G(label))
+		customCategories[L:G(label)] = true
 		categories:AddItemToCategory(item, L:G(label))
 		-- printChat("Added item '" .. id .. "' to '" .. label .. "' category")
 	end


### PR DESCRIPTION
Before PR: all items used for an itemrack set get put in the same category "Sets". This differs from the adibags_itemrack behavior where each set gets a named category. 

After PR: items found in an itemrack set are grouped in a new category named after the itemrack set

